### PR TITLE
Do not retry spec failures; fix eduspec consumer specs

### DIFF
--- a/smoketest-failing-api.sh
+++ b/smoketest-failing-api.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+# This file is part of eduhub-rio-mapper
+#
+# Copyright (C) 2022 SURFnet B.V.
+#
+# This program is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+
+set -e
+set -o pipefail
+
+COURSE_ID=8fca6e9e-4eb6-43da-9e78-4e1fad29abf0
+
+ENDPOINT="jomco.github.io" # ensure this corresponds to
+			   # institution-schac-home for client
+
+ACCESS_TOKEN=$(curl -s --request POST \
+  --url "${TOKEN_ENDPOINT}" \
+  --header 'content-type: application/x-www-form-urlencoded' \
+  --data grant_type=client_credentials \
+  --data "audience=${SURF_CONEXT_CLIENT_ID}" \
+  --user "${CLIENT_ID}:${CLIENT_SECRET}" |jq .access_token |tr -d \")
+
+EDUCATION_SPECIFICATION_ID="badded00-8ca1-c991-8d39-9a85d09cbcf5"
+
+# Now run the same commands through the web API
+
+export API_PORT=2345
+export API_HOSTNAME=localhost
+
+# run with trampoline because otherwise lein will fork a new process
+# and then we can't kill the server later
+lein trampoline mapper serve-api &
+API_SERVER_PID=$!
+trap "kill $API_SERVER_PID" EXIT
+
+lein trampoline mapper worker &
+WORKER_SERVER_PID=$!
+# Note: traps get overwritten
+trap "kill $API_SERVER_PID $WORKER_SERVER_PID" EXIT
+
+ROOT_URL="http://${API_HOSTNAME}:${API_PORT}"
+
+# Give api server some time to startup
+WAIT_SECS=120
+echo "Waiting for serve-api to come online.."
+while ! curl -s "$ROOT_URL"; do
+    WAIT_SECS=$((WAIT_SECS - 1))
+    if [ $WAIT_SECS = 0 ]; then
+        echo "Timeout waiting for serve-api to come online.." >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+URL="${ROOT_URL}/job/upsert/education-specifications/${EDUCATION_SPECIFICATION_ID}"
+echo Post upsert eduspec
+UPSERT_EDUSPEC_TOKEN=$(curl -sf -X POST -H "Authorization: Bearer ${ACCESS_TOKEN}" "$URL" | jq -r .token)
+echo "  token=$UPSERT_EDUSPEC_TOKEN"
+echo
+
+URL="${ROOT_URL}/job/delete/education-specifications/${EDUCATION_SPECIFICATION_ID}"
+echo Post delete eduspec
+DELETE_EDUSPEC_TOKEN=$(curl -sf -X POST -H "Authorization: Bearer ${ACCESS_TOKEN}" "$URL" | jq -r .token)
+echo "  token=$DELETE_EDUSPEC_TOKEN"
+echo
+
+
+UPSERT_EDUSPEC_DONE=
+DELETE_EDUSPEC_DONE=
+
+while [ -z "$UPSERT_EDUSPEC_DONE" ] || [ -z "$DELETE_EDUSPEC_DONE" ]; do
+    sleep 2
+
+    if [ -z "$UPSERT_EDUSPEC_DONE" ]; then
+        URL="$ROOT_URL/status/$UPSERT_EDUSPEC_TOKEN"
+        echo Status eduspec upsert
+        UPSERT_EDUSPEC_STATE=$(curl -sf -H "Authorization: Bearer ${ACCESS_TOKEN}" "$URL")
+        UPSERT_EDUSPEC_STATUS="$(echo "$UPSERT_EDUSPEC_STATE" | jq -r .status)"
+        echo "$UPSERT_EDUSPEC_STATE" | jq
+        echo
+        [ "$UPSERT_EDUSPEC_STATUS" = 'done' ] || [ "$UPSERT_EDUSPEC_STATUS" = 'error' ] \
+            && UPSERT_EDUSPEC_DONE=t
+    fi
+
+    if [ -z "$DELETE_EDUSPEC_DONE" ]; then
+        URL="$ROOT_URL/status/$DELETE_EDUSPEC_TOKEN"
+        echo Status eduspec delete
+        DELETE_EDUSPEC_STATE=$(curl -sf -H "Authorization: Bearer ${ACCESS_TOKEN}" "$URL")
+        DELETE_EDUSPEC_STATUS="$(echo "$DELETE_EDUSPEC_STATE" | jq -r .status)"
+        echo "$DELETE_EDUSPEC_STATE" | jq
+        echo
+        [ "$DELETE_EDUSPEC_STATUS" = 'done' ] || [ "$DELETE_EDUSPEC_STATUS" = 'error' ] \
+            && DELETE_EDUSPEC_DONE=t
+    fi
+done

--- a/src/nl/surf/eduhub_rio_mapper/job.clj
+++ b/src/nl/surf/eduhub_rio_mapper/job.clj
@@ -34,6 +34,7 @@
   {:pre [(or id opleidingscode) type action institution-schac-home institution-oin
          delete! update!]}
   (log/infof "Started job, action %s, type %s, id %s" action type id)
+  (prn "KEYS" (keys request))
   (let [job (select-keys request [:action :args :institution-oin :institution-schac-home
                                   ::rio/opleidingscode ::ooapi/type ::ooapi/id])]
     (try
@@ -44,6 +45,7 @@
       (catch Exception ex
         (let [error-id          (UUID/randomUUID)
               {:keys [phase
+                      invalid
                       message]} (ex-data ex)]
           (logging/log-exception ex error-id)
           {:errors {:error-id      error-id
@@ -55,4 +57,4 @@
                     ;; We consider all exceptions retryable because
                     ;; something unexpected happened and hopefully it
                     ;; won't next time we try.
-                    :retryable? true}})))))
+                    :retryable? (nil? invalid)}})))))

--- a/src/nl/surf/eduhub_rio_mapper/ooapi.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi.clj
@@ -49,7 +49,6 @@
         :course ::course
         :program ::program))
 
-
 (s/fdef education-specification-id
   :args (s/cat :entity ::entity)
   :ret ::id)

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/common.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/common.clj
@@ -41,6 +41,13 @@
                                 attr)))
        first))
 
+(defn extract-rio-consumer
+  "Find the first consumer with a consumerKey equal to 'rio' or return nil."
+  [consumers]
+  (some->> consumers
+           (filter #(= (:consumerKey %) "rio"))
+           first))
+
 (defn valid-date? [date]
   (and (string? date)
        (try (let [d (LocalDate/parse date date-format)]

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/education_specification.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/education_specification.clj
@@ -42,12 +42,21 @@
 
 (defn valid-type-and-subtype?
   "EducationSpecification should only have subType if type is 'program'."
-  [{:keys [educationSpecificationType
-           educationSpecificationSubType]
-    :as education-specification}]
-  (or (and (= educationSpecificationType "program")
-           (= educationSpecificationSubType "variant"))
-      (not (contains? education-specification :educationSpecificationSubType))))
+  [{:keys [educationSpecificationType consumers]}]
+  (let [{:keys [educationSpecificationSubType] :as rio-consumer} (common/extract-rio-consumer consumers)]
+    (or (and (= educationSpecificationType "program")
+             (= educationSpecificationSubType "variant"))
+        (not (contains? rio-consumer :educationSpecificationSubType)))))
+
+(s/def ::EducationSpecification/category (s/coll-of string?))
+(s/def ::EducationSpecification/rio-consumer
+  (s/keys :opt-un [::EducationSpecification/educationSpecificationSubType
+                   ::EducationSpecification/category]))
+
+(s/def ::EducationSpecification/consumerKey (s/and string? #(not= % "rio")))
+(s/def ::EducationSpecification/other-consumer (s/keys :req-un [::EducationSpecification/consumerKey]))
+(s/def ::EducationSpecification/consumer (s/or :other ::EducationSpecification/other-consumer :rio ::EducationSpecification/rio-consumer))
+(s/def ::EducationSpecification/consumers (s/coll-of ::EducationSpecification/consumer))
 
 (s/def ::EducationSpecification
   (s/and (s/keys :req-un
@@ -58,6 +67,7 @@
                  :opt-un
                  [::EducationSpecification/abbreviation
                   ::EducationSpecification/children
+                  ::EducationSpecification/consumers
                   ::EducationSpecification/description
                   ::EducationSpecification/educationSpecificationSubType
                   ::EducationSpecification/formalDocument

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/loader.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/loader.clj
@@ -129,6 +129,7 @@
     (when-not (s/valid? spec entity)
       (throw (ex-info "Entity fails spec"
                       {:phase   :fetching-ooapi
+                       :invalid true
                        :message (s/explain-str spec entity)}))))
   entity)
 

--- a/src/nl/surf/eduhub_rio_mapper/processing.clj
+++ b/src/nl/surf/eduhub_rio_mapper/processing.clj
@@ -111,8 +111,9 @@
     (try
       (f req)
       (catch Exception e
-        (let [phase (or (-> e (ex-data) :phase) phase)]
-          (throw (ex-info (str "Error during phase " phase) {:phase phase} e)))))))
+        (throw (ex-info (str "Error during phase " phase)
+                        (assoc (ex-data e) :phase phase)
+                        e))))))
 
 (defn- make-update [handlers]
   (let [fs [[:fetching-ooapi    (make-updater-load-ooapi-phase handlers)]

--- a/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
@@ -142,7 +142,7 @@
                             (map #(merge % course-program) (conj timelineOverrides {})))
 
             ;; These are in the xsd but ignored by us
-            :eigenAangebodenOpleidingSleutel id ;; resolve to the id
+            :eigenAangebodenOpleidingSleutel id ;; resolve to the ooapi id
             :opleidingserkenningSleutel nil
             :voVakerkenningSleutel nil))))))
 

--- a/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
@@ -41,13 +41,6 @@
           :else
           {:eenheid "M" :omvang (.toTotalMonths p)})))))
 
-(defn- extract-rio-consumer
-  "Find the first consumer with a consumerKey equal to 'rio' or return nil."
-  [consumers]
-  (some->> consumers
-           (filter #(= (:consumerKey %) "rio"))
-           first))
-
 (def ^:private education-specification-type-mapping
   {"course"         "aangebodenHOOpleidingsonderdeel"
    "cluster"        "aangebodenHOOpleidingsonderdeel"
@@ -102,7 +95,7 @@
   [{:keys [consumers startDate modeOfDelivery priceInformation
            flexibleEntryPeriodStart flexibleEntryPeriodEnd] :as offering}]
   (let [{:keys [registrationStatus requiredPermissionRegistration]
-         :as   _rio-consumer} (extract-rio-consumer consumers)]
+         :as   _rio-consumer} (common/extract-rio-consumer consumers)]
     (fn [ck]
       (if-let [translation (mapping-offering->cohort ck)]
         (translation offering)
@@ -157,11 +150,11 @@
   "Converts a program into the right kind of AangebodenOpleiding."
   [program education-specification-type opleidingscode]
   (let [object-name (education-specification-type-mapping education-specification-type)
-        rio-consumer (extract-rio-consumer (:consumers program))]
+        rio-consumer (common/extract-rio-consumer (:consumers program))]
     (rio/->xml (course-program-adapter program rio-consumer (:programId program) opleidingscode) object-name)))
 
 (defn course->aangeboden-opleiding
   "Converts a program into the right kind of AangebodenOpleiding."
   [course opleidingscode]
-  (let [rio-consumer (extract-rio-consumer (:consumers course))]
+  (let [rio-consumer (common/extract-rio-consumer (:consumers course))]
     (rio/->xml (course-program-adapter course rio-consumer (:courseId course) opleidingscode) "aangebodenHOOpleidingsonderdeel")))

--- a/src/nl/surf/eduhub_rio_mapper/rio/opleidingseenheid.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/opleidingseenheid.clj
@@ -56,7 +56,8 @@
    :opleidingseenheidcode         :rioId})
 
 (defn- education-specification-adapter
-  [{:keys [category formalDocument level levelOfQualification sector timelineOverrides fieldsOfStudy] :as eduspec}]
+  [{:keys [formalDocument level levelOfQualification sector timelineOverrides fieldsOfStudy] :as eduspec}
+   {:keys [category] :as _rio-consumer}]
   (fn [opl-eenh-attr-name]
     (if-let [translation (mapping-eduspec->opleidingseenheid opl-eenh-attr-name)]
       (translation eduspec)
@@ -74,5 +75,6 @@
 (defn education-specification->opleidingseenheid
   "Converts a program into the right kind of Opleidingseenheid."
   [eduspec]
-  (let [object-name (education-specification-type-mapping (:educationSpecificationType eduspec))]
-    (rio/->xml (education-specification-adapter eduspec) object-name)))
+  (let [object-name  (education-specification-type-mapping (:educationSpecificationType eduspec))
+        rio-consumer (common/extract-rio-consumer (:consumers eduspec))]
+    (rio/->xml (education-specification-adapter eduspec rio-consumer) object-name)))

--- a/test/nl/surf/eduhub_rio_mapper/ooapi/education_specification_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/ooapi/education_specification_test.clj
@@ -48,6 +48,10 @@
 (deftest validate-fixtures-custom-codetype
   (is (s/valid? ::es/EducationSpecification (assoc-in education-specification [:primaryCode :codeType] "x-undefined"))))
 
+(deftest validate-fixtures-invalid-subtype
+  (let [value (assoc-in education-specification [:consumers 0 :educationSpecificationSubType] "invalid")]
+    (is (not (s/valid? ::es/EducationSpecification value)))))
+
 (deftest validate-invalid-value-in-top-level-attribute
   (doseq [[key invalid-codes] [[:fieldsOfStudy ["12345" "123a"]]
                                [:formalDocument ["medal"]]


### PR DESCRIPTION
- Education specification needs rio-consumer, like program and course.
- Specs for eduspec/rio-consumer
- Do not retry ooapi spec failures
