### PR TITLE
Split RIO URL config in two

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,8 @@ jobs:
         KEYSTORE_JKS_B64: ${{ secrets.KEYSTORE_JKS_B64 }}
         KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
         RIO_RECIPIENT_OIN: ${{ secrets.RIO_RECIPIENT_OIN }}
-        RIO_ROOT_URL: ${{ secrets.RIO_ROOT_URL }}
+        RIO_READ_URL: ${{ secrets.RIO_READ_URL }}
+        RIO_UPDATE_URL: ${{ secrets.RIO_UPDATE_URL }}
         RIO_SENDER_OIN: ${{ secrets.RIO_SENDER_OIN }}
         SURF_CONEXT_CLIENT_ID: ${{ secrets.SURF_CONEXT_CLIENT_ID }}
         SURF_CONEXT_CLIENT_SECRET: ${{ secrets.SURF_CONEXT_CLIENT_SECRET }}

--- a/CLI.md
+++ b/CLI.md
@@ -28,16 +28,16 @@ KEYSTORE                            Path to keystore
 KEYSTORE_ALIAS                      Key alias in keystore
 KEYSTORE_PASSWORD                   Keystore password
 REDIS_KEY_PREFIX                    Prefix for redis keys
-REDIS_PASSWORD                      Password to redis
 REDIS_URI                           URI to redis
+RIO_READ_URL                        RIO Services Read URL
 RIO_RECIPIENT_OIN                   Recipient OIN for RIO SOAP calls
-RIO_ROOT_URL                        RIO Services Root URL
+RIO_UPDATE_URL                      RIO Services Update URL
 STATUS_TTL_SEC                      Number of seconds hours to keep job status
 SURF_CONEXT_CLIENT_ID               SurfCONEXT client id for Mapper service
 SURF_CONEXT_CLIENT_SECRET           SurfCONEXT client secret for Mapper service
 SURF_CONEXT_INTROSPECTION_ENDPOINT  SurfCONEXT introspection endpoint
-TRUSTSTORE                          Path to truststore
-TRUSTSTORE_PASSWORD                 Truststore password
+TRUSTSTORE                          Path to trust-store
+TRUSTSTORE_PASSWORD                 Trust-store password
 ```
 
 The `CLIENTS_INFO_PATH` should specify a json file with settings for client-id, schac-home and oin:

--- a/src/nl/surf/eduhub_rio_mapper/cli.clj
+++ b/src/nl/surf/eduhub_rio_mapper/cli.clj
@@ -56,8 +56,10 @@
                                         :in [:trust-store]] ; name compatibility with clj-http
    :truststore-password                ["Trust-store password" :str
                                         :in [:trust-store-pass]] ; name compatibility with clj-http
-   :rio-root-url                       ["RIO Services Root URL" :http
-                                        :in [:rio-config :root-url]]
+   :rio-read-url                       ["RIO Services Read URL" :str
+                                        :in [:rio-config :read-url]]
+   :rio-update-url                     ["RIO Services Update URL" :str
+                                        :in [:rio-config :update-url]]
    :rio-recipient-oin                  ["Recipient OIN for RIO SOAP calls" :str
                                         :in [:rio-config :recipient-oin]]
    :surf-conext-introspection-endpoint ["SurfCONEXT introspection endpoint" :http

--- a/src/nl/surf/eduhub_rio_mapper/rio/loader.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/loader.clj
@@ -114,7 +114,8 @@
 
   The resolver takes an `id` and an `institution-oin` and returns a
   map with errors, or the corresponding RIO opleidingscode."
-  [{:keys [root-url credentials recipient-oin]}]
+  [{:keys [read-url credentials recipient-oin]}]
+  {:pre [read-url]}
   (fn resolver
     [type id institution-oin]
     {:pre [institution-oin]}
@@ -134,7 +135,7 @@
           (handle-opvragen-request "rioIdentificatiecode"
                                    rio-resolver-response
                                    (assoc credentials
-                                     :url          (str root-url "raadplegen4.0")
+                                     :url          read-url
                                      :method       :post
                                      :body         xml
                                      :headers      {"SOAPAction" (str contract "/opvragen_rioIdentificatiecode")}
@@ -157,7 +158,8 @@
 
   The getter takes an program or course id and returns a map of
   data with the RIO attributes, or errors."
-  [{:keys [root-url credentials recipient-oin]}]
+  [{:keys [read-url credentials recipient-oin]}]
+  {:pre [read-url]}
   (fn getter [{::ooapi/keys [id] :keys [institution-oin pagina response-type] :or {pagina 0} ::rio/keys [type opleidingscode]}]
     (when-not (valid-get-actions type)
       (throw (ex-info "Invalid get action" {:action type})))
@@ -191,7 +193,7 @@
                                    (log-rio-action-response type element)
                                    ((response-handler-for-type response-type type) element))
                                  (assoc credentials
-                                   :url          (str root-url "raadplegen4.0")
+                                   :url          read-url
                                    :method       :post
                                    :body         xml
                                    :headers      {"SOAPAction" (str contract "/opvragen_" type)}

--- a/src/nl/surf/eduhub_rio_mapper/rio/mutator.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/mutator.clj
@@ -69,12 +69,12 @@
       clj-xml/parse-str
       xml-utils/xml-event-tree->edn))
 
-(defn mutate! [{:keys [action sender-oin rio-sexp] :as mutation} {:keys [recipient-oin credentials root-url]}]
-  {:pre [action recipient-oin sender-oin rio-sexp
+(defn mutate! [{:keys [action sender-oin rio-sexp] :as mutation} {:keys [recipient-oin credentials update-url]}]
+  {:pre [action recipient-oin sender-oin rio-sexp update-url
          (s/valid? ::Mutation/mutation-response mutation)
          (vector? (first rio-sexp))
          sender-oin]}
-  (-> {:url          (str root-url "beheren4.0")
+  (-> {:url          update-url
        :method       :post
        :body         (soap/prepare-soap-call action
                                              rio-sexp

--- a/test/nl/surf/eduhub_rio_mapper/mapper_integration_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/mapper_integration_test.clj
@@ -31,8 +31,15 @@
 (def institution-oin "123O321")
 (def rio-opleidingsid "1234O1234")
 (def ooapi-id "f2d020bc-5fac-b2e9-4ea7-4b35a08dfbeb")
-(def config {:rio-config {:credentials (keystore/credentials "test/keystore.jks" "xxxxxx" "test-surf" "truststore.jks" "xxxxxx")
-                          :recipient-oin "12345"}})
+(def config {:rio-config
+             {:credentials   (keystore/credentials "test/keystore.jks"
+                                                 "xxxxxx"
+                                                 "test-surf"
+                                                 "truststore.jks"
+                                                 "xxxxxx")
+              :recipient-oin "12345"
+              :read-url      "http://example.com"
+              :update-url    "http://example.com"}})
 
 (defn mock-ooapi-loader [{:keys [eduspec program-course offerings]}]
   (fn [{:keys [::ooapi/type]}]

--- a/test/nl/surf/eduhub_rio_mapper/relation_handler_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/relation_handler_test.clj
@@ -91,7 +91,7 @@
                                     4 "4234O1234"
                                     5 "5234O1234"))
                   :ooapi-loader (fn [{::ooapi/keys [id]}] (loader id))
-                  ; actual relations
+                  ;; actual relations
                   :getter       (fn [{::rio/keys [opleidingscode]}]
                                   (case opleidingscode
                                     "1234O1234" []
@@ -99,7 +99,15 @@
                                     "3234O1234" []
                                     "4234O1234" []
                                     "5234O1234" []))
-                  :rio-config   {:recipient-oin "1" :credentials (keystore/credentials "test/keystore.jks" "xxxxxx" "test-surf" "truststore.jks" "xxxxxx")}}]
+                  :rio-config   {:recipient-oin "1"
+                                 :read-url      "http://example.com"
+                                 :update-url    "http://example.com"
+                                 :credentials   (keystore/credentials
+                                                 "test/keystore.jks"
+                                                 "xxxxxx"
+                                                 "test-surf"
+                                                 "truststore.jks"
+                                                 "xxxxxx")}}]
     (binding [client/request (constantly {:status 200 :body (slurp "test/fixtures/rio/create-relation.xml")})]
       (testing "child with one parent"
         (let [{:keys [missing superfluous]} (rh/after-upsert (loader 1) job handlers)]


### PR DESCRIPTION
Because the paths in RIO environments aren't static, the old RIO_ROOT_URL config setting is split into RIO_UPDATE_URL and RIO_READ_URL

The test/dev settings should be:

```
export RIO_READ_URL=https://vt-webservice.duo.nl:6977/RIO/services/raadplegen4.0 
export RIO_UPDATE_URL=https://vt-webservice.duo.nl:6977/RIO/services/beheren4.0
```

See also https://trello.com/c/BU6eHiiK/104