### PR TITLE
Added token to mdc context for callbacks

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/cli.clj
+++ b/src/nl/surf/eduhub_rio_mapper/cli.clj
@@ -184,7 +184,11 @@
                           :message (-> data :errors :message))))
 
     (when (and callback-url (final-status? status))
-      (do-async-callback config job))))
+      (logging/with-mdc
+        {:token                  (:token job)
+         :url                    callback-url
+         :institution-schac-home (:institution-schac-home job)}
+        (do-async-callback config job)))))
 
 (defn errors?
   "Return true if `x` has errors."

--- a/src/nl/surf/eduhub_rio_mapper/logging.clj
+++ b/src/nl/surf/eduhub_rio_mapper/logging.clj
@@ -117,7 +117,12 @@
 
                   institution-oin
                   (assoc :institution-oin institution-oin))
-        (when-let [{:keys [status client-id institution-schac-home institution-oin] :as response} (f request)]
+        (when-let [{:keys [status
+                           client-id
+                           institution-schac-home
+                           institution-oin
+                           token] :as response}
+                   (f request)]
 
           (with-mdc (cond-> {:http_status status}
                       client-id
@@ -125,6 +130,9 @@
 
                       institution-schac-home
                       (assoc :institution-schac-home institution-schac-home)
+
+                      token
+                      (assoc :token token)
 
                       institution-oin
                       (assoc :institution-oin institution-oin))


### PR DESCRIPTION
As far as I can tell, all other logging statements have already included the jobs token in the mdc context, except for the logging statements that aren't executed in a job context.
