### PR TITLE
add soap action to logging

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/xml_validator.clj
+++ b/src/nl/surf/eduhub_rio_mapper/xml_validator.clj
@@ -49,7 +49,7 @@
     (fn validation
       [^String xmldoc]
       (when-let [ex (problems xmldoc)]
-        (throw (ex-info (str "XSD validation error in document: " (ex-message ex))
+        (throw (ex-info (str "XSD validation error in document: " (ex-message ex) "; schema-path: " schema-path)
                         {:doc        xmldoc
                          :retryable? false}
                         ex)))


### PR DESCRIPTION
- All logging includes trace-id and parent-id at toplevel of log message
- Added token to mdc context for callbacks
- Log soap-action and ooapi-id
