### PR TITLE
Fix modesOfDelivery spec

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/ooapi/common.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/common.clj
@@ -163,7 +163,7 @@
 (s/def ::modeOfDelivery
    (s/and (s/coll-of enums/modesOfDelivery)
          ;; for RIO at least one of the below is required
-         #(some #{"online" "hybrid" "situated"} %)))
+         #(some #{"online" "hybrid" "situated" "distance-learning" "on campus"} %)))
 
 (s/def ::sector enums/sectors)
 


### PR DESCRIPTION
@mdemare met de uitbreiding van de [modeOfDelivery mapping](https://openonderwijsapi.nl/#/technical/consumers-and-profiles/rio?id=modeofdelivery-opleidingsvorm) moet deze spec iets meer toestaan.