### PR TITLE
Adds the consumer query parameter when requesting offerings

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/ooapi/loader.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/loader.clj
@@ -42,8 +42,8 @@
         "education-specification" "education-specifications/%s?returnTimelineOverrides=true"
         "program" "programs/%s?returnTimelineOverrides=true"
         "course" "courses/%s?returnTimelineOverrides=true"
-        "course-offerings" (str "courses/%s/offerings?pageSize=" max-offerings)
-        "program-offerings" (str "programs/%s/offerings?pageSize=" max-offerings))
+        "course-offerings" (str "courses/%s/offerings?pageSize=" max-offerings "&consumer=rio")
+        "program-offerings" (str "programs/%s/offerings?pageSize=" max-offerings "&consumer=rio"))
       (format id)))
 
 ;; We should never receive /more/ than max-offerings items, but

--- a/test/fixtures/smoke/6-upsert-course/2-courses-8fca6e9e-4eb6-43da-9e78-4e1fad29abf0-offerings.edn
+++ b/test/fixtures/smoke/6-upsert-course/2-courses-8fca6e9e-4eb6-43da-9e78-4e1fad29abf0-offerings.edn
@@ -1,7 +1,7 @@
 {:request
  {:method :get,
   :url
-  "https://gateway.test.surfeduhub.nl/courses/8fca6e9e-4eb6-43da-9e78-4e1fad29abf0/offerings?pageSize=250",
+  "https://gateway.test.surfeduhub.nl/courses/8fca6e9e-4eb6-43da-9e78-4e1fad29abf0/offerings?pageSize=250&consumer=rio",
   :headers {"X-Route" "endpoint=jomco.github.io"}},
  :response
  {:status 200,

--- a/test/fixtures/smoke/9-upsert-course/2-courses-8fca6e9e-4eb6-43da-9e78-4e1fad29abf0-offerings.edn
+++ b/test/fixtures/smoke/9-upsert-course/2-courses-8fca6e9e-4eb6-43da-9e78-4e1fad29abf0-offerings.edn
@@ -1,7 +1,7 @@
 {:request
  {:method :get,
   :url
-  "https://gateway.test.surfeduhub.nl/courses/8fca6e9e-4eb6-43da-9e78-4e1fad29abf0/offerings?pageSize=250",
+  "https://gateway.test.surfeduhub.nl/courses/8fca6e9e-4eb6-43da-9e78-4e1fad29abf0/offerings?pageSize=250&consumer=rio",
   :headers {"X-Route" "endpoint=jomco.github.io"}},
  :response
  {:status 200,


### PR DESCRIPTION
This PR adds the `consumer=rio` query parameter when requesting offerings.