### PR TITLE
Add onderwijsbestuurcode to clients.json

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/api.clj
+++ b/src/nl/surf/eduhub_rio_mapper/api.clj
@@ -85,6 +85,7 @@
             {:job (-> request
                       (select-keys [:institution-schac-home
                                     :institution-oin
+                                    :onderwijsbestuurcodes
                                     :trace-context])
                       (assoc :action      action
                              ::ooapi/type type

--- a/src/nl/surf/eduhub_rio_mapper/clients_info.clj
+++ b/src/nl/surf/eduhub_rio_mapper/clients_info.clj
@@ -22,12 +22,14 @@
             [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
             [nl.jomco.http-status-codes :as http-status]
-            [nl.surf.eduhub-rio-mapper.logging :refer [with-mdc]]))
+            [nl.surf.eduhub-rio-mapper.logging :refer [with-mdc]]
+            [nl.surf.eduhub-rio-mapper.ooapi.common :as common]))
 
 (s/def ::client-info
   (s/keys :req-un [::institution-oin
                    ::institution-schac-home
-                   ::client-id]))
+                   ::client-id
+                   ::common/onderwijsbestuurcodes]))
 
 (s/def ::clients
   (s/coll-of ::client-info))

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/common.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/common.clj
@@ -77,6 +77,12 @@
 (s/def ::educationOffererCode
   (re-spec #"\d\d\dA\d\d\d"))
 
+(s/def ::onderwijsbestuurcode
+  (re-spec #"\d\d\dB\d\d\d"))
+
+(s/def ::onderwijsbestuurcodes
+  (s/coll-of ::onderwijsbestuurcode))
+
 (s/def ::LanguageTypedString/language
   (re-spec #"^[a-z]{2,4}(-[A-Z][a-z]{3})?(-([A-Z]{2}|[0-9]{3}))?$"))
 

--- a/test/nl/surf/eduhub_rio_mapper/clients_info_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/clients_info_test.clj
@@ -24,5 +24,6 @@
   (let [info (clients-info/read-clients-data {:path "test/test-clients.json"})]
     (is (= {:client-id              "rio-mapper-dev6.jomco.nl"
             :institution-schac-home "demo06.test.surfeduhub.nl"
-            :institution-oin        "0000000700025BE00000"}
+            :institution-oin        "0000000700025BE00000"
+            :onderwijsbestuurcodes  ["100B490"]}
            (clients-info/client-info info "rio-mapper-dev6.jomco.nl")))))

--- a/test/test-clients.json
+++ b/test/test-clients.json
@@ -3,21 +3,19 @@
   [{
     "client-id": "rio-mapper-dev6.jomco.nl",
     "institution-schac-home": "demo06.test.surfeduhub.nl",
-    "institution-oin": "0000000700025BE00000"
+    "institution-oin": "0000000700025BE00000",
+    "onderwijsbestuurcodes": ["100B490"]
   },
   {
     "client-id": "rio-mapper-dev4.jomco.nl",
     "institution-schac-home": "demo04.test.surfeduhub.nl",
-    "institution-oin": "0000000700025BE00000"
+    "institution-oin": "0000000700025BE00000",
+    "onderwijsbestuurcodes": ["100B490"]
   },
   {
     "client-id": "rio-mapper-dev.jomco.nl",
     "institution-schac-home": "jomco.github.io",
-    "institution-oin": "0000000700025BE00000"
-  },
-  {
-    "client-id": "wur.jomco.nl",
-    "institution-schac-home": "wur-acc-pe.ascme.nl",
-    "institution-oin": "0000000700021PI00000"
+    "institution-oin": "0000000700025BE00000",
+    "onderwijsbestuurcodes": ["100B490"]
   }]
 }


### PR DESCRIPTION
Nodig voor de dry-run. 

Een OIN heeft een 1-1 mapping met een BRIN, dus de vraag is of een BRIN 1-1 een 1-1 mapping heeft met een onderwijsbestuur. Gerwin Meijer zegt hier het volgende over:

> Nou, dat is grotendeels waar, maar niet helemaal... een BRIN kan ihkv splitsingen of fusies natuurlijk bij een ander bevoegd gezag en daarmee onderwijsbestuur landen (op ieder moment heeft hij dan 1 bevoegd gezag / bestuur, maar die kan in de tijd dus wisselen). Daarnaast is het in uitzonderlijke situaties (bijv. in MBO) mogelijk dat er samenwerkingen ontstaan waarbij een BRIN onder twee besturen valt... ik weet niet of dat in het HO speelt, maar helemaal waterdicht is het denk ik niet. Dit is overigens ook de reden dat er 1..* bijbehorende besturen mogelijk zijn. De actuele (of geldige) kun je afleiden van de organisatierelatie begin-/einddatum. 

Er komt waarschijnlijk een opvragen_opleidingseenheid call, en dan is het niet nodig om de onderwijsbestuurcode op te nemen in de clients.json, maar tot die tijd moeten de opleidingseenheden opvragen via een call die een onderwijsbestuurcode als parameter vraagt. Derhalve stel ik voor om de onderwijsbestuurcode voorlopig op te slaan in clients.json.

