### PR TITLE
Cleaned up adapters opl eenh and aangeb opl

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
@@ -156,4 +156,5 @@
   "Converts a program or course into the right kind of AangebodenOpleiding."
   [course-program ooapi-type opleidingscode education-specification-type]
   (-> (course-program-adapter course-program opleidingscode ooapi-type)
+      rio/wrapper-periodes-cohorten
       (rio/->xml (education-specification-type-mapping education-specification-type))))

--- a/src/nl/surf/eduhub_rio_mapper/rio/opleidingseenheid.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/opleidingseenheid.clj
@@ -86,6 +86,6 @@
 (defn education-specification->opleidingseenheid
   "Converts a education specification into the right kind of Opleidingseenheid."
   [eduspec]
-  (let [object-name  (education-specification-type-mapping (:educationSpecificationType eduspec))
-        rio-consumer (common/extract-rio-consumer (:consumers eduspec))]
-    (rio/->xml (education-specification-adapter eduspec rio-consumer) object-name)))
+  (-> (education-specification-adapter eduspec (common/extract-rio-consumer (:consumers eduspec)))
+      rio/wrapper-periodes-cohorten
+      (rio/->xml (education-specification-type-mapping (:educationSpecificationType eduspec)))))


### PR DESCRIPTION
Cleaned up this part of the code, which uses the XSD files to convert ooapi object to rio xml, in order to make it more generic and allow it to also use rio xml from the Raadplegen api as input, which is slightly different than in the Beheren api.