### PR TITLE
identificatiecode

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                    org.clojure/clojurescript]]
                  [commons-io "2.11.0"]
                  [compojure "1.7.0"]
-                 [info.sunng/ring-jetty9-adapter "0.18.5"]
+                 [info.sunng/ring-jetty9-adapter "0.19.0"]
                  [nl.jomco/envopts "0.0.4"]
                  [nl.jomco/ring-trace-context "0.0.8"]
                  [nl.jomco/clj-http-status-codes "0.1"]

--- a/src/nl/surf/eduhub_rio_mapper/rio/loader.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/loader.clj
@@ -63,7 +63,9 @@
   (= "true" (single-xml-unwrapper element "ns2:requestGoedgekeurd")))
 
 (defn log-rio-action-response [msg element]
-  (log/debugf (format "RIO %s; SUCCESS: %s" msg (goedgekeurd? element))))
+  (logging/with-mdc
+    {:identificatiecodeBedrijfsdocument (single-xml-unwrapper element "ns2:identificatiecodeBedrijfsdocument")}
+    (log/debugf (format "RIO %s; SUCCESS: %s" msg (goedgekeurd? element)))))
 
 (defn- rio-resolver-response [^Element element]
   {:pre [element]}


### PR DESCRIPTION
- Upgraded jetty adapter
- Add identificatiecodeBedrijfsdocument to logging

Example:

```
{"timestamp":"2023-04-03T08:27:51.344Z","mdc":{"institution-schac-home":"jomco.github.io","identificatiecodeBedrijfsdocument":"6f415714-ef90-4dcf-a8bf-c2b2b8e3c3ea","trace-id":"9e1cce6ccf38c9e75aa35bab0a49ed80","soap-action":"opvragen_rioIdentificatiecode","trace-flags":"#{}","ooapi-id":"fddec347-8ca1-c991-8d39-9a85d09c0004","institution-oin":"0000000700025BE00000","parent-id":"b999343a81ad80bf","version":"00","token":"c88bc35b-2550-44c8-b044-8dbb293279ba"},"message":"RIO RESOLVE FAILED - ID: fddec347-8c...a85d09c0004; SUCCESS: false"}
```
