### PR TITLE
In status, use attributes instead of link/dry-run

### DIFF
--- a/API.md
+++ b/API.md
@@ -181,15 +181,19 @@ POST /job/link/1234O4321/programs/ffeeddcc-bbaa-0099-8877-665544332211
 POST /job/link/1234O4321/courses/ffeeddcc-bbaa-0099-8877-665544332211
 ```
 
-Bij de status wordt doorgegeven of de call geslaagd is, en of het object gevonden kon worden.
+Bij de status wordt doorgegeven of de call geslaagd is, en wat de oorspronkelijke sleutel was.
 
 ```json
 {
   "status": "done",
   "token": "00112233-4455-6677-8899-aabbccddeeff",
   "resource": "education-specifications/ffeeddcc-bbaa-0099-8877-665544332211",
-  "link": {
-    "status": "found"
+  "attributes": {
+    "eigenOpleidingseenheidSleutel": {
+      "diff": true,
+      "old-id": "<id-old>",
+      "new-id": "<id>"
+    }
   }
 }
 ```
@@ -213,7 +217,7 @@ welke gegevens aangepast zouden worden:
   "status": "done",
   "token": "00112233-4455-6677-8899-aabbccddeeff",
   "resource": "education-specifications/ffeeddcc-bbaa-0099-8877-665544332211",
-  "dry-run": {
+  "attributes": {
     "begindatum": {
       "diff": true,
       "current": "2023-01-01",

--- a/src/nl/surf/eduhub_rio_mapper/cli.clj
+++ b/src/nl/surf/eduhub_rio_mapper/cli.clj
@@ -203,10 +203,10 @@
                                         (assoc :attributes {:aangebodenopleidingcode id})
 
                                         (:dry-run data)
-                                        (assoc :dry-run (:dry-run data))
+                                        (assoc :attributes (:dry-run data))
 
                                         (:link data)
-                                        (assoc :link (:link data))
+                                        (assoc :attributes (:link data))
 
                                         (#{:error :time-out} status)
                                         (assoc :phase (-> data :errors :phase)

--- a/src/nl/surf/eduhub_rio_mapper/processing.clj
+++ b/src/nl/surf/eduhub_rio_mapper/processing.clj
@@ -328,7 +328,6 @@
                         :rio-sexp   [(linker rio-new)]
                         :sender-oin institution-oin}
               _success  (mutator/mutate! mutation rio-config)]
-          ;{:link (assoc result :status (if success "found" "not-found"))}
           {:link result})))))
 
 (defn make-handlers

--- a/src/nl/surf/eduhub_rio_mapper/processing.clj
+++ b/src/nl/surf/eduhub_rio_mapper/processing.clj
@@ -192,7 +192,7 @@
     (mapv #(if (:tag %) (xmlclj->duo-hiccup %) %)
          (:content x))))
 
-  (defn- make-dry-runner [{:keys [rio-config ooapi-loader resolver getter] :as _handlers}]
+(defn- make-dry-runner [{:keys [rio-config ooapi-loader resolver getter] :as _handlers}]
   {:pre [rio-config]}
   (fn [{::ooapi/keys [type id] :keys [institution-oin onderwijsbestuurcode] :as request}]
     {:pre [(:institution-oin request)
@@ -310,7 +310,7 @@
 
           rio-obj  (rio-finder getter rio-config request)]
       (if (nil? rio-obj)
-        {:link {:status "not-found"}}
+        (throw (ex-info "404 Not Found" {:phase :resolving}))
         (let [rio-obj  (xmlclj->duo-hiccup rio-obj)
               rio-obj (map #(if (and (sequential? %)
                                      (= :duo:opleidingseenheidcode (first %)))
@@ -321,14 +321,15 @@
               old-id   (some finder rio-obj)
               new-id   id
               rio-new  (mapv (sleutel-changer new-id finder) rio-obj)
-              result   (if (= old-id new-id)
-                         {:diff false}
-                         {:diff true :old-id old-id :new-id new-id})
+              result   {(keyword sleutelnaam) (if (= old-id new-id)
+                                                {:diff false}
+                                                {:diff true :old-id old-id :new-id new-id})}
               mutation {:action     action
                         :rio-sexp   [(linker rio-new)]
                         :sender-oin institution-oin}
-              success  (mutator/mutate! mutation rio-config)]
-      {:link (assoc result :status (if success "found" "not-found"))})))))
+              _success  (mutator/mutate! mutation rio-config)]
+          ;{:link (assoc result :status (if success "found" "not-found"))}
+          {:link result})))))
 
 (defn make-handlers
   [{:keys [rio-config

--- a/test/nl/surf/eduhub_rio_mapper/smoke_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/smoke_test.clj
@@ -32,7 +32,8 @@
     [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
     [nl.surf.eduhub-rio-mapper.processing :as processing]
     [nl.surf.eduhub-rio-mapper.rio :as rio])
-  (:import [java.io PushbackReader]))
+  (:import [clojure.lang ExceptionInfo]
+           [java.io PushbackReader]))
 
 (defn- ls [dir-name]
   (map #(.getName %) (.listFiles (io/file dir-name))))
@@ -293,7 +294,7 @@
                               ::ooapi/id "11111112-dfc3-4a30-874e-000000000001"
                               ::ooapi/type "education-specification"
                               ::rio/code "1010O6466"))]
-          (is (= {:link {:diff true, :old-id "11111111-dfc3-4a30-874e-000000000001", :new-id "11111112-dfc3-4a30-874e-000000000001", :status "found"}}
+          (is (= {:link {:eigenOpleidingseenheidSleutel {:diff true, :old-id "11111111-dfc3-4a30-874e-000000000001", :new-id "11111112-dfc3-4a30-874e-000000000001"}}}
                  result)))))
     (testing "courses"
       (binding [http-utils/*vcr* (vcr "test/fixtures/aangebodenopl-link" 1 "linker")]
@@ -301,7 +302,7 @@
                                  ::ooapi/id "11111111-dfc3-4a30-874e-000000000001"
                                  ::ooapi/type "course"
                                  ::rio/code "bd6cb46b-3f4e-49c2-a1f7-e24ae82b0672"))]
-          (is (= {:link {:diff true, :old-id nil, :new-id "11111111-dfc3-4a30-874e-000000000001", :status "found"}}
+          (is (= {:link {:eigenAangebodenOpleidingSleutel {:diff true, :old-id nil, :new-id "11111111-dfc3-4a30-874e-000000000001"}}}
                  result)))))
     (testing "program"
       (binding [http-utils/*vcr* (vcr "test/fixtures/aangebodenopl-link" 2 "linker")]
@@ -309,16 +310,15 @@
                               ::ooapi/id "11111111-dfc3-4a30-874e-000000000002"
                               ::ooapi/type "program"
                               ::rio/code "ab7431c0-f985-4742-aa68-42060570b17e"))]
-          (is (= {:link {:diff true, :old-id nil, :new-id "11111111-dfc3-4a30-874e-000000000002", :status "found"}}
+          (is (= {:link {:eigenAangebodenOpleidingSleutel {:diff true, :old-id nil, :new-id "11111111-dfc3-4a30-874e-000000000002"}}}
                  result)))))
     (testing "missing program"
       (binding [http-utils/*vcr* (vcr "test/fixtures/aangebodenopl-link" 3 "linker")]
-        (let [result (link! (assoc client-info
-                              ::ooapi/id "11111111-dfc3-4a30-874e-000000000002"
-                              ::ooapi/type "program"
-                              ::rio/code "00000000-d8e8-4868-b451-157180ab0001"))]
-          (is (= {:link {:status "not-found"}}
-                 result)))))))
+        (let [request (assoc client-info
+                        ::ooapi/id "11111111-dfc3-4a30-874e-000000000002"
+                        ::ooapi/type "program"
+                        ::rio/code "00000000-d8e8-4868-b451-157180ab0001")]
+          (is (thrown-with-msg? ExceptionInfo #"404 Not Found" (link! request))))))))
 
 (deftest opleidingseenheid-finder-diff-test
   (let [eduspec-id  "fddec347-8ca1-c991-8d39-9a85d09c0001"


### PR DESCRIPTION
Trello ticket 1:

Key dry-run zou wat ons betreft ‘attributes’ worden.
```
{
  "status": "done",
  "token": "e2949cb0-1079-4059-ade4-b4b422b3d090",
  "resource": "education-specification/9338214e-3978-484c-676d-427303a92748",
  "attributes": {
    "status": "not-found",
    ....
  }
}
```

Trello ticket 2

We denken dat het format van de link job status nog wat verbeterd zou kunnen worden.
Dit is hoe we het zouden willen:

```
{
  "status": "done",
  "token": "8d9bd787-b882-46b9-8dbd-ac77585266b7",
  "resource": "program/4c358c84-dfc3-4a30-874e-000000000000",
  "attributes": {
    "eigenOpleidingseenheidSleutel": {
      "diff": true,
      "old-id": "<id-old>",
      "new-id": "<id>"
    }
  }
}
```