### PR TITLE
Allow Dutch or English in the education specification name

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/ooapi/common.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/common.clj
@@ -149,16 +149,12 @@
 (s/def ::LongLanguageTypedStrings
   (s/coll-of ::LongLanguageTypedString))
 
-;; A collection of language typed strings with at least one dutch entry
-(s/def ::nlLanguageTypedStrings
+;; A collection of language typed strings with at least one dutch or
+;; english entry
+(s/def ::nlOrEnLanguageTypedStrings
   (s/cat :head (s/* ::LanguageTypedString)
-         :nl ::nlLanguageTypedString
-         :tail (s/* ::LanguageTypedString)))
-
-;; A collection of language typed strings with at least one english entry
-(s/def ::enLanguageTypedStrings
-  (s/cat :head (s/* ::LanguageTypedString)
-         :en ::enLanguageTypedString
+         :nlOrEn (s/or :nl ::nlLanguageTypedString
+                       :en ::enLanguageTypedString)
          :tail (s/* ::LanguageTypedString)))
 
 (s/def ::codeType
@@ -171,7 +167,10 @@
 
 (s/def ::StudyLoadDescriptor/value number?)
 (s/def ::StudyLoadDescriptor/studyLoadUnit enums/studyLoadUnits)
-(s/def ::studyLoad (s/keys :req-un [::StudyLoadDescriptor/studyLoadUnit ::StudyLoadDescriptor/value]))
+(s/def ::studyLoad
+  (s/keys :req-un
+          [::StudyLoadDescriptor/studyLoadUnit
+           ::StudyLoadDescriptor/value]))
 
 ;; XSD says 0-999 for ISCED, so broad/narrow fields.  OOAPI spec def
 ;; is 4 digits, so it accepts detailed fields. See also

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/education_specification.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/education_specification.clj
@@ -33,7 +33,7 @@
   enums/educationSpecificationTypes)
 
 (s/def ::EducationSpecification/formalDocument enums/formalDocumentTypes)
-(s/def ::EducationSpecification/name ::common/nlLanguageTypedStrings)
+(s/def ::EducationSpecification/name ::common/nlOrEnLanguageTypedStrings)
 (s/def ::EducationSpecification/link (text-spec 1 2048))
 (s/def ::EducationSpecification/parent ::common/uuid)
 (s/def ::EducationSpecification/primaryCode ::common/codeTuple)


### PR DESCRIPTION
If no Dutch name is provided, we will use the English name.